### PR TITLE
Deploy Automatizado com Caminhos de Upload de Arquivo para Inferencia Corrigida

### DIFF
--- a/EngSoft/EngSoft/settings.py
+++ b/EngSoft/EngSoft/settings.py
@@ -145,7 +145,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 MEDIA_URL = 'media/'
 
 # Define a url para imagens que forem upadas via browser (em producao)
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_ROOT = '/app/Engsoft/media/'
 
 # >>>>>>> Mailchimp credentials <<<<<<<<
 

--- a/EngSoft/EngSoft/settings.py
+++ b/EngSoft/EngSoft/settings.py
@@ -145,7 +145,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 MEDIA_URL = 'media/'
 
 # Define a url para imagens que forem upadas via browser (em producao)
-MEDIA_ROOT = '/app/Engsoft/media/'
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
 # >>>>>>> Mailchimp credentials <<<<<<<<
 

--- a/EngSoft/prediction/utils.py
+++ b/EngSoft/prediction/utils.py
@@ -11,6 +11,8 @@ def initPrediction(img_path):
 
     img_height = 180
     img_width = 180
+
+    print(img_path)
     
     img = keras.preprocessing.image.load_img(
         img_path, target_size=(img_height, img_width)

--- a/EngSoft/prediction/views.py
+++ b/EngSoft/prediction/views.py
@@ -52,7 +52,7 @@ def predicao(request):
         if DEBUG:
             destination_folder = f'{BASE_DIR}/prediction/images/{uploaded_image_name}'
         else:
-        # diretorio de upload quando em producao
+            # diretorio de upload quando em producao
             destination_folder = f'{BASE_DIR}/media/prediction/images/{uploaded_image_name}'
 
         # Salva a imagem carregada em um local temporario
@@ -61,7 +61,7 @@ def predicao(request):
 
         # Correcao na string para que ela contemple a base app/Engsoft/media
         image_path = f'{BASE_DIR}/media/{image_path}'
-        
+
         # Inicializa a predicao
         label_and_score = initPrediction(image_path)
         return JsonResponse({'result': label_and_score})

--- a/EngSoft/prediction/views.py
+++ b/EngSoft/prediction/views.py
@@ -59,6 +59,9 @@ def predicao(request):
         fs = FileSystemStorage()
         image_path = fs.save(destination_folder, uploaded_image)
 
+        # Correcao na string para que ela contemple a base app/Engsoft/media
+        image_path = f'{BASE_DIR}/media/{image_path}'
+        
         # Inicializa a predicao
         label_and_score = initPrediction(image_path)
         return JsonResponse({'result': label_and_score})

--- a/EngSoft/prediction/views.py
+++ b/EngSoft/prediction/views.py
@@ -49,7 +49,7 @@ def predicao(request):
         uploaded_image_name = uploaded_image.name
 
         # diretorio de upload quando em desenvolvimento
-        if DEBUG is 1:
+        if DEBUG:
             destination_folder = f'{BASE_DIR}/prediction/images/{uploaded_image_name}'
         else:
         # diretorio de upload quando em producao

--- a/EngSoft/prediction/views.py
+++ b/EngSoft/prediction/views.py
@@ -6,10 +6,10 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 from django.core.files.storage import FileSystemStorage
 from .utils import initPrediction
-from EngSoft.settings import BASE_DIR
+from EngSoft.settings import BASE_DIR, DEBUG
 
 def image_view(request):
-    
+
     # A imagem carregada pela interface
     image = ModelImage.objects.filter(name='example').first()
 
@@ -48,12 +48,17 @@ def predicao(request):
         uploaded_image = request.FILES['image']
         uploaded_image_name = uploaded_image.name
 
-        destination_folder = f'{BASE_DIR}/prediction/images/{uploaded_image_name}' 
-        
+        # diretorio de upload quando em desenvolvimento
+        if DEBUG is 1:
+            destination_folder = f'{BASE_DIR}/prediction/images/{uploaded_image_name}'
+        else:
+        # diretorio de upload quando em producao
+            destination_folder = f'{BASE_DIR}/media/prediction/images/{uploaded_image_name}'
+
         # Salva a imagem carregada em um local temporario
         fs = FileSystemStorage()
         image_path = fs.save(destination_folder, uploaded_image)
-        
+
         # Inicializa a predicao
         label_and_score = initPrediction(image_path)
         return JsonResponse({'result': label_and_score})


### PR DESCRIPTION
Havia um erro que impedia a imagem Docker (contendo a aplicação) de localizar a pasta específica que continha as imagens enviadas. Esse problema estava relacionado à estrutura do sistema de arquivos em camadas do Docker. Resolvi ajustando a referência de caminho para garantir que a aplicação dentro do contêiner pudesse acessar corretamente a pasta de imagens upadas em produção